### PR TITLE
Respect CFLAGS/CXXFLAGS

### DIFF
--- a/cmake/ConkyBuildOptions.cmake
+++ b/cmake/ConkyBuildOptions.cmake
@@ -37,10 +37,10 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 
 # -std options for all build types
-set(CMAKE_C_FLAGS "-std=c99"
+set(CMAKE_C_FLAGS "-std=c99 ${CMAKE_C_FLAGS}"
     CACHE STRING "Flags used by the C compiler during all build types."
     FORCE)
-set(CMAKE_CXX_FLAGS "-std=c++17"
+set(CMAKE_CXX_FLAGS "-std=c++17 ${CMAKE_CXX_FLAGS}"
     CACHE STRING "Flags used by the C++ compiler during all build types."
     FORCE)
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
**Descriptions**
In commit https://github.com/brndnmtthws/conky/commit/bb8723dd361d15be0077ab9270292b96572415e6 "add toluapp subtree" support for user defined FLAGS was removed. I do not see a reason why this should not be allowed, so it would be great if this could be added again.

**Notes**
Reference: https://bugs.gentoo.org/772176